### PR TITLE
Upgrade to Automa 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-Automa = "0.8"
+Automa = "1"
 OrderedCollections = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Fixes #2.  Tests are passing, should add more tests to make sure everything is still working.

- fixes the header regex due to an unsecaped dot in `re"# STOCKHOLM 1\.0"`

- seqname can't begin with a slash anymore, maybe this is fixable in the future